### PR TITLE
gcode script variables

### DIFF
--- a/octoprint_preheat/__init__.py
+++ b/octoprint_preheat/__init__.py
@@ -245,7 +245,16 @@ class PreheatAPIPlugin(octoprint.plugin.TemplatePlugin,
 				self._logger.info("Preheat error: " + str(error.message))
 				return str(error.message), 405
 
-				
+	def gcode_script_variables(self, comm, script_type, script_name, *args, **kwargs):
+		if not script_type == "gcode" or not script_name == "beforePrintStarted":
+			return None
+
+		prefix = None
+		postfix = None
+		variables = self.get_temperatures()
+		return prefix, postfix, variables
+
+
 	def get_update_information(self, *args, **kwargs):
 		return dict(
 			preheat = dict(
@@ -266,5 +275,6 @@ __plugin_name__ = "Preheat Button"
 __plugin_implementation__ = PreheatAPIPlugin()
 
 __plugin_hooks__ = {
-	"octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+	"octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+	"octoprint.comm.protocol.scripts": __plugin_implementation__.gcode_script_variables
 }


### PR DESCRIPTION
This change basically allows for referencing the derived print temperatures retrieved by the plugin to be used in the GCODE 'Before Print Starts` script. Additional discussion on this request can be seen on the Community forum post [here](https://community.octoprint.org/t/is-it-possible-to-use-variables-in-gcode-scripts-for-the-starting-temp-of-the-print-file/13878/13).

Added GCODE Script variables can be referenced as follows.
`{{ plugins.preheat.tool0|int() }}` = selected file's extruder temperature
`{{ plugins.preheat.bed|int() }}` = selected file's bed temperature