### PR TITLE
Added support for custom limit on gcode lines to look at

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wik
 or manually using this URL:
 
     https://github.com/marian42/octoprint-preheat/archive/master.zip
+
+## Troubleshooting
+
+If you have a printer that adds image data to the top of the G-Code file (Prusa Mini), the default of checking the first 1000 lines for set temperature commands might not be enough. Use the setting labeled "Max number of lines to look for preheat commands" to adjust how many lines are looked at.

--- a/octoprint_preheat/__init__.py
+++ b/octoprint_preheat/__init__.py
@@ -37,7 +37,8 @@ class PreheatAPIPlugin(octoprint.plugin.TemplatePlugin,
 					on_complete_show_popup = False,
 					on_conplete_send_gcode = False,
 					on_conplete_send_gcode_command = "M117 Preheat complete. ; Update LCD\nM300 S660 P200 ; Beep",
-					use_fallback_when_no_file_selected = False
+					use_fallback_when_no_file_selected = False,
+					max_gcode_lines = 1000
 		)
 
 					
@@ -88,7 +89,7 @@ class PreheatAPIPlugin(octoprint.plugin.TemplatePlugin,
 
 		file = open(path_on_disk, 'r')
 		line = file.readline()
-		max_lines = 1000
+		max_lines = self._settings.get_int(["max_gcode_lines"])
 		temperatures = dict()
 		current_tool = "tool0"
 		try:

--- a/octoprint_preheat/templates/preheat_settings.jinja2
+++ b/octoprint_preheat/templates/preheat_settings.jinja2
@@ -17,14 +17,20 @@
         <div class="controls">
             <input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.enable_chamber">
         </div>
-		<br><br>
-		
+        <br>
+
+        <label class="control-label">Max number of lines to look for preheat commands</label>
+        <div class="controls">
+          <input type="number" step="1" min="0" class="input-mini text-right" data-bind="value: settings.plugins.preheat.max_gcode_lines">
+        </div>
+    <br><br>
+
 		<legend>Fallback Temperatures</legend>
 		<div>
 			Fallback temperatures are used if the gcode file is on the SD card or if no heating command was found in the gcode file.
 			Set these to 0 to not preheat in these cases.
 		</div>
-		
+
 		<div class="preheat_settings_item">
 			<label class="control-label preheat_long_label">Fallback temperature for tool preheating</label>
 			<div class="input-append">
@@ -56,7 +62,7 @@
 
 		<legend>Sequenced Preheating</legend>
         <div>
-			Preheat bed and chamber first, heat printheads once the bed and chamber has 
+			Preheat bed and chamber first, heat printheads once the bed and chamber has
 			reached its target temperature.
 			If this option is disabled, the bed, chamber and printheads are heated right away.
 			If you don't have a heated bed or chamber, this option makes no difference.


### PR DESCRIPTION
this allows gcode files with images stored at the top to still function

PrusaSlicer can add a gcode comment that is actually an image. they can be quite large so the temperature gcode lines are much further down. This adds flexibility.