### PR TITLE
Added auto preheat option and functionality

### DIFF
--- a/octoprint_preheat/templates/preheat_settings.jinja2
+++ b/octoprint_preheat/templates/preheat_settings.jinja2
@@ -1,29 +1,35 @@
 <form class="form-horizontal">
-    <div class="control-group">
+	<div class="control-group">
 		<legend>Enable Preheating</legend>
-        <label class="control-label">Enable tool preheating</label>
-        <div class="controls">
-            <input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.enable_tool">
-        </div>
-        <br>
+		<label class="control-label">Enable tool preheating</label>
+		<div class="controls">
+			<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.enable_tool">
+		</div>
+		<br>
 
 		<label class="control-label">Enable bed preheating</label>
-        <div class="controls">
-            <input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.enable_bed">
-        </div>
-        <br>
+		<div class="controls">
+			<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.enable_bed">
+		</div>
+		<br>
 
-        <label class="control-label">Enable chamber preheating</label>
-        <div class="controls">
-            <input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.enable_chamber">
-        </div>
-        <br>
+		<label class="control-label">Enable chamber preheating</label>
+		<div class="controls">
+			<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.enable_chamber">
+		</div>
+		<br>
 
-        <label class="control-label">Max number of lines to look for preheat commands</label>
-        <div class="controls">
-          <input type="number" step="1" min="0" class="input-mini text-right" data-bind="value: settings.plugins.preheat.max_gcode_lines">
-        </div>
-    <br><br>
+		<label class="control-label">Enable automatic preheating on file selection</label>
+		<div class="controls">
+			<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.auto_preheat">
+		</div>
+		<br>
+
+		<label class="control-label">Max number of lines to look for preheat commands</label>
+		<div class="controls">
+			<input type="number" step="1" min="0" class="input-mini text-right" data-bind="value: settings.plugins.preheat.max_gcode_lines">
+		</div>
+		<br><br>
 
 		<legend>Fallback Temperatures</legend>
 		<div>
@@ -55,9 +61,9 @@
 			</div>
 		</div>
 		<label class="control-label preheat_long_label">Use fallback temperatures to preheat when no file is selected</label>
-        <div class="controls">
-            <input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.use_fallback_when_no_file_selected">
-        </div>
+		<div class="controls">
+			<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.use_fallback_when_no_file_selected">
+		</div>
 		<br><br>
 
 		<legend>Temperature offsets</legend>
@@ -90,19 +96,19 @@
 		<br><br>
 		
 		<legend>Sequenced Preheating</legend>
-        <div>
+		<div>
 			Preheat bed and chamber first, heat printheads once the bed and chamber has
 			reached its target temperature.
 			If this option is disabled, the bed, chamber and printheads are heated right away.
 			If you don't have a heated bed or chamber, this option makes no difference.
 		</div>
 		<label class="control-label">Enable</label>
-        <div class="controls">
-            <input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.wait_for_bed">
-        </div>
+		<div class="controls">
+			<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.wait_for_bed">
+		</div>
 		<br> <br>
 		<legend>Before Preheating</legend>
-        <div class="preheat_settings_item">
+		<div class="preheat_settings_item">
 			<label class="control-label">Send gcode</label>
 			<div class="controls">
 				<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.on_start_send_gcode">
@@ -135,13 +141,13 @@
 		<br><br>
 		
 		<legend>Use M109/M190/M191 commands</legend>
-        <div>
+		<div>
 			Use M109/M190/M191 commands to set the temperature in addition to the regular temperature commands.
 			This will instruct the printer to wait until the temperature is reached and in turn will activate LEDs on some printers.
 		</div>
 		<label class="control-label">Enable</label>
-        <div class="controls">
-            <input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.use_m109">
-        </div>
-    </div>
+		<div class="controls">
+			<input type="checkbox" class="input-block-level" data-bind="checked: settings.plugins.preheat.use_m109">
+		</div>
+	</div>
 </form>


### PR DESCRIPTION
I was too lazy to even click the preheat button of this great plugin, so I added an option to enable automatic preheating on selecting a file. It should also stop heating if the file is deselected, although I don't have an idea how to actually trigger that.

The only thing I did not get correct was the placement of the checkbox in the settings menu, could you please look into that @marian42 ?